### PR TITLE
feat: upgrade to Python 3.13 and optimize CI/CD workflows

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,4 +1,5 @@
 name: "Setup Python and Poetry"
+
 description: "Sets up Python, installs Poetry, caches dependency environments, and installs dependencies."
 
 inputs:
@@ -15,7 +16,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-
     - name: Set up Python
       id: setup-python
       uses: actions/setup-python@v5
@@ -28,6 +28,12 @@ runs:
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Export PATH for Poetry
+      # This step ensures that any new PATH directories from snok/install-poetry
+      # are retained for the subsequent steps in the composite action.
+      shell: bash
+      run: echo "PATH=${HOME}/.poetry/bin:\$PATH" >> $GITHUB_ENV
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -5,12 +5,15 @@ inputs:
   python_version:
     description: "Python version to use."
     required: false
-    default: "3.13"
+    default: "3.12"
 
 outputs:
   python_version:
     description: "The Python version that was installed."
     value: ${{ steps.setup-python.outputs.python-version }}
+  venv_cache_hit:
+    description: "Whether the virtual environment cache was hit."
+    value: ${{ steps.cached-poetry-dependencies.outputs.cache-hit }}
 
 runs:
   using: "composite"
@@ -21,7 +24,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
-        cache: "poetry"
+        cache: "pip"
 
     - name: Cache Poetry installation
       uses: actions/cache@v4
@@ -35,7 +38,15 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
     - name: Install dependencies
+      if: ${{ steps.cached-poetry-dependencies.outputs.cache-hit != 'true' }}
       shell: bash
       run: poetry install --no-interaction --no-ansi
 
@@ -44,3 +55,4 @@ runs:
       shell: bash
       run: |
         echo "python_version=${{ steps.setup-python.outputs.python-version }}" >> $GITHUB_OUTPUT
+        echo "venv_cache_hit=${{ steps.cached-poetry-dependencies.outputs.cache-hit }}" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -29,11 +29,10 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Export PATH for Poetry
-      # This step ensures that any new PATH directories from snok/install-poetry
-      # are retained for the subsequent steps in the composite action.
+    - name: Add Poetry to PATH
       shell: bash
-      run: echo "PATH=${HOME}/.poetry/bin:\$PATH" >> $GITHUB_ENV
+      run: |
+        echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,5 +1,4 @@
 name: "Setup Python and Poetry"
-
 description: "Sets up Python, installs Poetry, caches dependency environments, and installs dependencies."
 
 inputs:
@@ -16,6 +15,7 @@ outputs:
 runs:
   using: "composite"
   steps:
+
     - name: Set up Python
       id: setup-python
       uses: actions/setup-python@v5
@@ -23,17 +23,21 @@ runs:
         python-version: ${{ inputs.python_version }}
         cache: "poetry"
 
-    - name: Install Poetry and dependencies
+    - name: Cache Poetry installation
+      uses: actions/cache@v4
+      with:
+        path: ~/.local
+        key: poetry-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Install dependencies
       shell: bash
-      run: |
-        # (Optional) Upgrade pip
-        python -m pip install --upgrade pip
-
-        # Install Poetry via pip
-        pip install poetry
-
-        # Now, we can call `poetry` in the same script
-        poetry install --no-ansi --no-interaction
+      run: poetry install --no-interaction --no-ansi
 
     - name: Set outputs
       id: set-outputs

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -23,20 +23,17 @@ runs:
         python-version: ${{ inputs.python_version }}
         cache: "poetry"
 
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
-    - name: Add Poetry to PATH
+    - name: Install Poetry and dependencies
       shell: bash
       run: |
-        echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+        # (Optional) Upgrade pip
+        python -m pip install --upgrade pip
 
-    - name: Install dependencies
-      shell: bash
-      run: poetry install --no-interaction --no-ansi
+        # Install Poetry via pip
+        pip install poetry
+
+        # Now, we can call `poetry` in the same script
+        poetry install --no-ansi --no-interaction
 
     - name: Set outputs
       id: set-outputs

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -5,15 +5,12 @@ inputs:
   python_version:
     description: "Python version to use."
     required: false
-    default: "3.12"
+    default: "3.13"
 
 outputs:
   python_version:
     description: "The Python version that was installed."
     value: ${{ steps.setup-python.outputs.python-version }}
-  venv_cache_hit:
-    description: "Whether the virtual environment cache was hit."
-    value: ${{ steps.cached-poetry-dependencies.outputs.cache-hit }}
 
 runs:
   using: "composite"
@@ -24,13 +21,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
-        cache: "pip"
-
-    - name: Cache Poetry installation
-      uses: actions/cache@v4
-      with:
-        path: ~/.local
-        key: poetry-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}
+        cache: "poetry"
 
     - name: Install Poetry
       uses: snok/install-poetry@v1
@@ -38,15 +29,7 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
     - name: Install dependencies
-      if: ${{ steps.cached-poetry-dependencies.outputs.cache-hit != 'true' }}
       shell: bash
       run: poetry install --no-interaction --no-ansi
 
@@ -55,4 +38,3 @@ runs:
       shell: bash
       run: |
         echo "python_version=${{ steps.setup-python.outputs.python-version }}" >> $GITHUB_OUTPUT
-        echo "venv_cache_hit=${{ steps.cached-poetry-dependencies.outputs.cache-hit }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         id: setup-poetry
         uses: ./.github/actions/setup-poetry
         with:
-          python_version: "3.12"
+          python_version: "3.13"
 
       - name: Conventional Commits Check
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,36 +25,23 @@ jobs:
         with:
           python_version: "3.12"
 
-      - name: Determine commit range
-        id: commit_range
-        run: |
-          if [ -n "$GITHUB_BASE_REF" ]; then
-            echo "Running in PR context: Checking commits from origin/$GITHUB_BASE_REF..HEAD"
-            echo "REV_RANGE=origin/$GITHUB_BASE_REF..HEAD" >> $GITHUB_OUTPUT
-          else
-            BASE=$(git merge-base HEAD origin/${GITHUB_REF#refs/heads/})
-            echo "Running in push context: Checking commits from $BASE..HEAD"
-            echo "REV_RANGE=$BASE..HEAD" >> $GITHUB_OUTPUT
-          fi
-
       - name: Conventional Commits Check
+        env:
+          REV_RANGE: "origin/${{ github.base_ref }}..HEAD"
         run: |
-          rev_range="${{ steps.commit_range.outputs.REV_RANGE }}"
-          echo "Checking commits with range: $rev_range"
-          poetry run cz check --rev-range "$rev_range"
+          echo "Checking commits with range: $REV_RANGE"
+          poetry run cz check --rev-range "$REV_RANGE"
 
   lint-and-test:
     needs: [commit-check]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.13"]
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python and Poetry
         id: setup-poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-poetry
         uses: ./.github/actions/setup-poetry
         with:
-          python_version: "3.12"
+          python_version: "3.13"
 
       - name: Configure git identity
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,15 @@ repos:
       - id: check-ast
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.1.1

--- a/cmdc/cli.py
+++ b/cmdc/cli.py
@@ -1,16 +1,15 @@
-# cmdc/cli.py
-import typer
+import sys
 from pathlib import Path
 from typing import List, Optional
-import sys
 
-from cmdc import __version__, ASCII_ART
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from cmdc import ASCII_ART, __version__
 from cmdc.config_manager import ConfigManager
 from cmdc.file_browser import FileBrowser
 from cmdc.output_handler import OutputHandler
-
-from rich.console import Console
-from rich.panel import Panel
 
 app = typer.Typer(
     help="Interactive CLI tool for browsing and selecting files for LLM contexts.",

--- a/cmdc/config_manager.py
+++ b/cmdc/config_manager.py
@@ -68,6 +68,13 @@ class ConfigManager:
             ".tox",
             ".mypy_cache",
             ".ruff_cache",
+            "*.log",
+            ".terraform",
+            ".terraform.lock.hcl",
+            "*.tfstate",
+            "*.tfstate.backup",
+            "*.tfvars",
+            "*.tfvars.json",
         ]
 
     @staticmethod

--- a/cmdc/config_manager.py
+++ b/cmdc/config_manager.py
@@ -149,17 +149,7 @@ class ConfigManager:
             amark="✓",
         ).execute()
 
-        if use_default_ignores:
-            ignore_patterns = inquirer.checkbox(
-                message="Select patterns to ignore:",
-                instruction="Space to toggle, Enter to confirm, ctrl+a to select all",
-                choices=default_patterns,
-                default=default_patterns,
-                style=style,
-                amark="✓",
-            ).execute()
-        else:
-            ignore_patterns = []
+        ignore_patterns = default_patterns if use_default_ignores else []
 
         # Allow adding custom patterns
         while inquirer.confirm(

--- a/cmdc/config_manager.py
+++ b/cmdc/config_manager.py
@@ -8,6 +8,7 @@ from InquirerPy import inquirer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+
 from cmdc.prompt_style import get_custom_style, get_style
 
 console = Console()

--- a/cmdc/file_browser.py
+++ b/cmdc/file_browser.py
@@ -1,25 +1,25 @@
-from pathlib import Path
-from typing import List, Iterable, Optional, Tuple
-
 import fnmatch
 import os
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
 import typer
 from InquirerPy import inquirer
 from InquirerPy.base.control import Choice
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import (
+    BarColumn,
     Progress,
     SpinnerColumn,
-    TextColumn,
-    BarColumn,
     TaskProgressColumn,
+    TextColumn,
     TimeRemainingColumn,
 )
 from rich.tree import Tree
 
-from cmdc.utils import build_directory_tree, count_tokens
 from cmdc.prompt_style import get_custom_style
+from cmdc.utils import build_directory_tree, count_tokens
 
 console = Console()
 

--- a/cmdc/output_handler.py
+++ b/cmdc/output_handler.py
@@ -1,7 +1,7 @@
-from pathlib import Path
-from typing import List, Iterable
-from io import StringIO
 import fnmatch
+from io import StringIO
+from pathlib import Path
+from typing import Iterable, List
 
 import pyperclip
 import typer
@@ -9,8 +9,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 
-from cmdc.utils import build_directory_tree
 from cmdc.config_manager import ConfigManager
+from cmdc.utils import build_directory_tree
 
 console = Console()
 

--- a/cmdc/utils.py
+++ b/cmdc/utils.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Callable, Iterable
-from rich.tree import Tree
+from typing import Callable, Dict, Iterable, List
+
 import tiktoken
+from rich.tree import Tree
 
 
 def clear_console() -> None:


### PR DESCRIPTION
### Changes
- Upgraded default Python version from 3.12 to 3.13 across workflows
- Simplified Poetry caching strategy using native poetry cache
- Removed redundant venv caching layers
- Streamlined CI workflow by simplifying commit range checks
- Updated test matrix to focus on Python 3.9 and 3.13
- Added additional pre-commit hooks for security and code quality
- Added terraform-related patterns to default ignores
- Various code organization improvements and import sorting

### Technical Details
- Leverages actions/setup-python@v5's built-in poetry caching
- Removes manual Poetry installation caching and venv caching
- Simplifies commit range determination in CI workflow
- Adds checks for large files and private keys in pre-commit
- Improves code organization with consistent import ordering